### PR TITLE
avoid having a dependency on REPL

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,9 @@ authors = ["Tim Holy <tim.holy@gmail.com>"]
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-REPL = "1.10"
 julia = "1.10"
 
 [extras]

--- a/src/CodeTracking.jl
+++ b/src/CodeTracking.jl
@@ -15,7 +15,6 @@ using Core: LineInfoNode, MethodTable
 using Base.Meta: isexpr
 using UUIDs
 using InteractiveUtils
-using REPL: REPL
 
 export code_expr, @code_expr, code_string, @code_string, whereis, definition, pkgfiles, signatures_at
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -334,14 +334,15 @@ function src_from_file_or_REPL(origin::AbstractString, args...)
     return read(origin, String)
 end
 
-function src_from_REPL(origin::AbstractString, repl = Base.active_repl)
+function src_from_REPL(origin::AbstractString, repl = isdefined(Base, :active_repl) ? Base.active_repl : nothing)
+    repl === nothing && return nothing
     hist_idx = parse(Int, origin)
-    hp = repl.interface.modes[1].hist::REPL.REPLHistoryProvider
+    hp = repl.interface.modes[1].hist
     entry = hp.history[hp.start_idx+hist_idx]
     @static if VERSION ≥ v"1.13-"
-        return entry.content
+        return entry.content::String
     else
-        return entry
+        return entry::String
     end
 end
 


### PR DESCRIPTION
Doesn't make sense to load the full REPL just for a type assert